### PR TITLE
Enable sway feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-tokio-i3ipc = "0.12.1"
+tokio-i3ipc = { version = "0.12.1", features = ["sway"] }
 tokio = { version = "1.9.0", default-features = false, features = ["rt-multi-thread", "macros", "sync"] }
 anyhow = "1.0.42"
 log = "0.4.14"


### PR DESCRIPTION
i3-auto-layout works on [sway](https://github.com/swaywm/sway/), with this patch, and I've been using it with no problems. I'd be happy to upstream it if you'll accept.