### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-tokio-i3ipc = "0.13.0"
+tokio-i3ipc = "0.14.0"
 tokio = { version = "1.9.0", default-features = false, features = ["rt-multi-thread", "macros", "sync"] }
 anyhow = "1.0.42"
 log = "0.4.14"


### PR DESCRIPTION
Updated tokio-i3ipc version to 0.14.0, since 0.13.0 was yanked from crates.io.
Tested and is fully functional with new version